### PR TITLE
Remove communicationsCompleteDate

### DIFF
--- a/src/main/java/cord/common/AllProperties.java
+++ b/src/main/java/cord/common/AllProperties.java
@@ -13,7 +13,6 @@ public enum AllProperties {
   budget,
   ceremony,
   code,
-  communicationsCompleteDate,
   completeDate,
   countryOfOrigin,
   createdAt,

--- a/src/main/java/cord/model/InternshipEngagement.java
+++ b/src/main/java/cord/model/InternshipEngagement.java
@@ -3,7 +3,6 @@ package cord.model;
 public enum InternshipEngagement {
 canDelete,
   ceremony,                  
-communicationsCompleteDate,
 completeDate,              
 countryOfOrigin,           
 disbursementCompleteDate,  

--- a/src/main/java/cord/model/LanguageEngagement.java
+++ b/src/main/java/cord/model/LanguageEngagement.java
@@ -3,7 +3,6 @@ package cord.model;
 public enum LanguageEngagement {
 canDelete,
   ceremony,                  
-communicationsCompleteDate,
 completeDate,              
 disbursementCompleteDate,  
 endDate,                   

--- a/src/main/java/cord/roles/Administrator.java
+++ b/src/main/java/cord/roles/Administrator.java
@@ -180,7 +180,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -233,7 +232,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Consultant.java
+++ b/src/main/java/cord/roles/Consultant.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/ConsultantManager.java
+++ b/src/main/java/cord/roles/ConsultantManager.java
@@ -167,7 +167,6 @@ public class ConsultantManager extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.NO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ public class ConsultantManager extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.NO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Controller.java
+++ b/src/main/java/cord/roles/Controller.java
@@ -167,7 +167,6 @@ public class Controller extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RO;
-      case communicationsCompleteDate: return Perm.RO;
       case completeDate:               return Perm.RO;
       case countryOfOrigin:            return Perm.RO;
       case disbursementCompleteDate:   return Perm.RO;
@@ -217,7 +216,6 @@ public class Controller extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RO;
-      case communicationsCompleteDate: return Perm.RO;
       case completeDate:               return Perm.RO;
       case disbursementCompleteDate:   return Perm.RO;
       case endDate:                    return Perm.RO;

--- a/src/main/java/cord/roles/FieldOperationsDirector.java
+++ b/src/main/java/cord/roles/FieldOperationsDirector.java
@@ -167,7 +167,6 @@ public class FieldOperationsDirector extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ public class FieldOperationsDirector extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/FinancialAnalystGlobal.java
+++ b/src/main/java/cord/roles/FinancialAnalystGlobal.java
@@ -167,7 +167,6 @@ public class FinancialAnalystGlobal extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RO;
-      case communicationsCompleteDate: return Perm.RO;
       case completeDate:               return Perm.RO;
       case countryOfOrigin:            return Perm.RO;
       case disbursementCompleteDate:   return Perm.RO;
@@ -217,7 +216,6 @@ public class FinancialAnalystGlobal extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RO;
-      case communicationsCompleteDate: return Perm.RO;
       case completeDate:               return Perm.RO;
       case disbursementCompleteDate:   return Perm.RO;
       case endDate:                    return Perm.RO;

--- a/src/main/java/cord/roles/FinancialAnalystOnProject.java
+++ b/src/main/java/cord/roles/FinancialAnalystOnProject.java
@@ -167,7 +167,6 @@ public class FinancialAnalystOnProject extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ public class FinancialAnalystOnProject extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Fundraising.java
+++ b/src/main/java/cord/roles/Fundraising.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Intern.java
+++ b/src/main/java/cord/roles/Intern.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Leadership.java
+++ b/src/main/java/cord/roles/Leadership.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Liaison.java
+++ b/src/main/java/cord/roles/Liaison.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Marketing.java
+++ b/src/main/java/cord/roles/Marketing.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Mentor.java
+++ b/src/main/java/cord/roles/Mentor.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/ProjectManagerGlobal.java
+++ b/src/main/java/cord/roles/ProjectManagerGlobal.java
@@ -167,7 +167,6 @@ public class ProjectManagerGlobal extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RO;
-      case communicationsCompleteDate: return Perm.RO;
       case completeDate:               return Perm.RO;
       case countryOfOrigin:            return Perm.RO;
       case disbursementCompleteDate:   return Perm.RO;
@@ -217,7 +216,6 @@ public class ProjectManagerGlobal extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RO;
-      case communicationsCompleteDate: return Perm.RO;
       case completeDate:               return Perm.RO;
       case disbursementCompleteDate:   return Perm.RO;
       case endDate:                    return Perm.RO;

--- a/src/main/java/cord/roles/ProjectManagerOnProject.java
+++ b/src/main/java/cord/roles/ProjectManagerOnProject.java
@@ -167,7 +167,6 @@ public class ProjectManagerOnProject extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ public class ProjectManagerOnProject extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/RegionalCommunicationCoordinator.java
+++ b/src/main/java/cord/roles/RegionalCommunicationCoordinator.java
@@ -167,7 +167,6 @@ public class RegionalCommunicationCoordinator extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ public class RegionalCommunicationCoordinator extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/RegionalDirectorGlobal.java
+++ b/src/main/java/cord/roles/RegionalDirectorGlobal.java
@@ -167,7 +167,6 @@ public class RegionalDirectorGlobal extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RO;
-      case communicationsCompleteDate: return Perm.RO;
       case completeDate:               return Perm.RO;
       case countryOfOrigin:            return Perm.RO;
       case disbursementCompleteDate:   return Perm.RO;
@@ -217,7 +216,6 @@ public class RegionalDirectorGlobal extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RO;
-      case communicationsCompleteDate: return Perm.RO;
       case completeDate:               return Perm.RO;
       case disbursementCompleteDate:   return Perm.RO;
       case endDate:                    return Perm.RO;

--- a/src/main/java/cord/roles/RegionalDirectorOnProject.java
+++ b/src/main/java/cord/roles/RegionalDirectorOnProject.java
@@ -167,7 +167,6 @@ public class RegionalDirectorOnProject extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ public class RegionalDirectorOnProject extends BaseRole {
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/StaffMember.java
+++ b/src/main/java/cord/roles/StaffMember.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;

--- a/src/main/java/cord/roles/Translator.java
+++ b/src/main/java/cord/roles/Translator.java
@@ -167,7 +167,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case countryOfOrigin:            return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
@@ -217,7 +216,6 @@ return Perm.NO;
         switch(property){
       case canDelete:                  return Perm.RO;
       case ceremony:                   return Perm.RW;
-      case communicationsCompleteDate: return Perm.RW;
       case completeDate:               return Perm.RW;
       case disbursementCompleteDate:   return Perm.RW;
       case endDate:                    return Perm.RW;


### PR DESCRIPTION
Ken has handled the occurrences of this field in Domo already, so no need to coordinate with him.

"The new posts API and removal of communicationscompletedate s/b ok to push whenever." - Ken

See https://github.com/SeedCompany/cord-api-v3/issues/1892

UI: https://github.com/SeedCompany/cord-field/pull/869
API: https://github.com/SeedCompany/cord-api-v3/pull/1957
Seed-API: https://github.com/SeedCompany/seed-api/pull/128